### PR TITLE
use `onUnhandledRequest` to ignore static assets

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,7 +18,15 @@ async function enableMocking() {
 		return;
 	}
 	const { worker } = await import("./mocks/browser");
-	await worker.start();
+	await worker.start({
+		onUnhandedRequest(request, print) {
+			if (/\.(png|jpg|jpeg|svg|gif)$/.test(request.url.href)) {
+				return;
+			}
+
+			print.warning();
+		}
+	});
 }
 
 enableMocking().then(() => {

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -11,10 +11,6 @@ const wsLink = ws.link("ws://localhost:8080");
 export const worker = setupWorker(
 	// REST API mocking
 	http.get("/api/v1/data", () => HttpResponse.json(mockData)),
-	// passthrough
-	http.get("*.png", () => {
-		return passthrough();
-	}),
 	// WS mocking
 	wsLink.on("connection", ({ client }) => {
 		client.addEventListener("message", (event) => {


### PR DESCRIPTION
Hi 👋 
Thanks for the demo and the [article](https://www.cookielab.io/blog/mock-service-worker-vyuziti-pro-testovani-i-vyvoj)! 

In this pull request I suggest one change to the code: you don't need the `passthrough()` handler for static assets (images). MSW bypasses all requests by default. You just need to instruct it not to warn you on unhandled requests for static assets by providing the `onUnhandledRequest` option to `worker.start()`. 